### PR TITLE
Add build tools to fix coincurve build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.7.2-alpine3.8
 
 RUN python -m pip install --upgrade pip
 RUN apk add --no-cache \
+    alpine-sdk \
     zlib \
     libjpeg-turbo-dev \
     libpng-dev \


### PR DESCRIPTION
Running through docker-compose failed for me because client image failed to install **coincurve** dependency because of the missing **make** tool. Added alpine-sdk package to install all the native build tools.